### PR TITLE
fixed redirecting of logged in user on page load

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,7 @@
 import { useAuthStore } from '@/stores/auth';
 import LandingPageView from '@/views/LandingPageView.vue';
 import { storeToRefs } from 'pinia';
-import { createRouter, createWebHashHistory } from 'vue-router';
+import { START_LOCATION, createRouter, createWebHashHistory } from 'vue-router';
 
 const router = createRouter({
   history: createWebHashHistory(import.meta.env.BASE_URL),
@@ -61,10 +61,18 @@ const router = createRouter({
   ],
 });
 
-router.beforeEach((to) => {
-  const { setPostLoginDestination } = useAuthStore();
+router.beforeEach(async (to, from) => {
+  const { setPostLoginDestination, loadUserFromLocalStorage } = useAuthStore();
   const { user } = storeToRefs(useAuthStore());
   const requiresAuth = to.matched.some((route) => route.meta.requiresAuth);
+
+  if (from === START_LOCATION) {
+    if (requiresAuth) {
+      await loadUserFromLocalStorage();
+    } else {
+      loadUserFromLocalStorage();
+    }
+  }
 
   if (requiresAuth && !user.value.roles.includes('ROLE_USER')) {
     setPostLoginDestination(to.name != null && to.name !== 'login' ? to.name : 'home');

--- a/src/stores/auth.spec.ts
+++ b/src/stores/auth.spec.ts
@@ -107,72 +107,6 @@ describe('Auth Store', () => {
     expect(authError.value).toBe('Username and Password cannot be blank.');
   });
 
-  // it('should handle errors: 401 response status', async () => {
-  //   const loginDto: LoginDto = {
-  //     username: 'some_user',
-  //     password: 'some_password',
-  //   };
-
-  //   // const mockResponse: AxiosResponse<any, any> = {
-  //   //   status: 401,
-  //   //   data: undefined,
-  //   //   statusText: '',
-  //   //   headers: {},
-  //   //   config: {} as any,
-  //   // };
-
-  //   // const error = new AxiosError();
-  //   // error.response = mockResponse;
-
-  //   const mockResponse: ErrorResponse = {
-  //     status: 400,
-  //     type: 'error',
-  //     error: 'Username and Password cannot be blank.',
-  //   };
-
-  //   const { login } = useAuthStore();
-  //   const { user, authError } = storeToRefs(useAuthStore());
-
-  //   vi.mocked(authService.login).mockRejectedValue(error);
-
-  //   await login(loginDto);
-
-  //   expect(authService.login).toHaveBeenCalledOnce();
-  //   expect(user.value).toStrictEqual(emptyUser);
-  //   expect(JSON.parse(localStorage.getItem('user') ?? '{}')).toStrictEqual({});
-  //   expect(authError.value).toBe('Your login attempt failed. Please try again.');
-  // });
-
-  // it('should handle errors: server errors', async () => {
-  //   const loginDto: LoginDto = {
-  //     username: 'some_user',
-  //     password: 'some_password',
-  //   };
-
-  //   const mockResponse: AxiosResponse<any, any> = {
-  //     status: 500,
-  //     data: undefined,
-  //     statusText: '',
-  //     headers: {},
-  //     config: {} as any,
-  //   };
-
-  //   const error = new AxiosError();
-  //   error.response = mockResponse;
-
-  //   const { login } = useAuthStore();
-  //   const { user, authError } = storeToRefs(useAuthStore());
-
-  //   vi.mocked(authService.login).mockRejectedValue(error);
-
-  //   await login(loginDto);
-
-  //   expect(authService.login).toHaveBeenCalledOnce();
-  //   expect(user.value).toStrictEqual(emptyUser);
-  //   expect(JSON.parse(localStorage.getItem('user') ?? '{}')).toStrictEqual({});
-  //   expect(authError.value).toBe('Something went wrong on our end. Try again later.');
-  // });
-
   it('should logout a user and redirect to login', async () => {
     const { logout } = useAuthStore();
     const { user } = storeToRefs(useAuthStore());
@@ -209,9 +143,10 @@ describe('Auth Store', () => {
 
     localStorage.setItem('user', JSON.stringify(mockUser));
 
+    const { loadUserFromLocalStorage } = useAuthStore();
     const { user } = storeToRefs(useAuthStore());
 
-    await flushPromises();
+    await loadUserFromLocalStorage();
 
     expect(user.value).toEqual(mockUser);
   });
@@ -233,9 +168,10 @@ describe('Auth Store', () => {
 
     localStorage.setItem('user', JSON.stringify(mockUser));
 
+    const { loadUserFromLocalStorage } = useAuthStore();
     const { user } = storeToRefs(useAuthStore());
 
-    await flushPromises();
+    await loadUserFromLocalStorage();
 
     expect(user.value).toEqual(emptyUser);
   });
@@ -253,9 +189,10 @@ describe('Auth Store', () => {
 
     localStorage.setItem('user', '{"username": "some_user", "roles": ["ROLE_USER"], }');
 
+    const { loadUserFromLocalStorage } = useAuthStore();
     const { user } = storeToRefs(useAuthStore());
 
-    await flushPromises();
+    await loadUserFromLocalStorage();
 
     expect(user.value).toEqual(emptyUser);
   });
@@ -338,5 +275,25 @@ describe('Auth Store', () => {
     const response = await attemptToRefreshToken(config);
 
     expect(response).toBe('logout successful');
+  });
+
+  it('should handle an error while retrieving user from localstorage', async () => {
+    const mockUser: User = {
+      username: 'some_user',
+      roles: ['ROLE_USER'],
+    };
+
+    const error = new Error();
+
+    const consoleMock = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(authService.refreshToken).mockRejectedValue(error);
+
+    localStorage.setItem('user', JSON.stringify(mockUser));
+
+    const { loadUserFromLocalStorage } = useAuthStore();
+
+    await loadUserFromLocalStorage();
+
+    expect(consoleMock).toHaveBeenCalledOnce();
   });
 });

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -15,7 +15,6 @@ export const useAuthStore = defineStore('auth', () => {
     roles: [],
   };
   const user = ref<User>(emptyUser);
-  loadUserFromLocalStorage();
   const authError = ref('');
   const postLoginDestination = ref<RouteRecordName>('');
 
@@ -111,5 +110,6 @@ export const useAuthStore = defineStore('auth', () => {
     logout,
     attemptToRefreshToken,
     setPostLoginDestination,
+    loadUserFromLocalStorage,
   };
 });


### PR DESCRIPTION
Bug Reported By @ThePudgyPigeon 

## Before:
When a logged in user refreshed the page, the route guard would execute before their information was loaded/verified from localStorage. This would result in them being redirected to the login screen despite still being logged in.

## After:
I moved the loadUserFromLocalStorage function to the route guard itself. If the route requires auth, it will await the result and verify the user is logged in. If the route does not require auth, it will execute asynchronously so as to not hinder page load time.